### PR TITLE
Porting the .env change from tinkerbell.org

### DIFF
--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -67,11 +67,11 @@ vagrant@provisioner:~$
 Tinkerbell is going to be running from a container, so navigate to the `vagrant` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
 
 ```
-cd /vagrant && source envrc && cd deploy
+cd /vagrant && source .env && cd deploy
 docker-compose up -d
 ```
 
-The Tinkerbell server, and more importantly the CLI, are now managed like a standard Docker Compose project. Just make sure to have sourced the `envrc` before issuing docker-compose commands.
+The Tinkerbell server, and more importantly the CLI, are now managed like a standard Docker Compose project. Just make sure to have sourced the `.env` before issuing docker-compose commands.
 
 Tinkerbell is now ready to receive templates and workflows. Check out all the Tinkerbell services are running.
 
@@ -95,7 +95,7 @@ At this point, you might want to open a ssh connection to show logs from the Pro
 ```
 cd tink/deploy/vagrant
 vagrant ssh provisioner
-cd /vagrant && source envrc && cd deploy
+cd /vagrant && source .env && cd deploy
 docker-compose logs -f tink-server boots nginx
 ```
 

--- a/docs/setup/packet-terraform.md
+++ b/docs/setup/packet-terraform.md
@@ -109,11 +109,11 @@ SSH into the Provisioner and you will find yourself in a copy of the `tink` repo
 ssh -t root@$(terraform output provisioner_ip) "cd /root/tink && bash"
 ```
 
-You have to define and set Tinkerbell's environment. Use the `generate-envrc.sh` script to generate the `envrc` file. Using and setting `envrc` creates an idempotent workflow and you can use it to configure the `setup.sh` script. For example changing the [OSIE](/docs/services/osie) version.
+You have to define and set Tinkerbell's environment. Use the `generate-envrc.sh` script to generate the `.env` file. Using and setting `.env` creates an idempotent workflow and you can use it to configure the `setup.sh` script. For example changing the [OSIE](/docs/services/osie) version.
 
 ```
-./generate-envrc.sh enp1s0f1 > envrc
-source ./envrc
+./generate-envrc.sh enp1s0f1 > .env
+source .env
 ```
 
 Then, you run the `setup.sh` script.
@@ -122,7 +122,7 @@ Then, you run the `setup.sh` script.
 ./setup.sh
 ```
 
-`setup.sh` uses the `envrc` to install and configure:
+`setup.sh` uses the `.env` to install and configure:
 
 - [tink-server](/docs/services/tink)
 - [hegel](/docs/services/hegel)


### PR DESCRIPTION
Signed-off-by: DailyAlice <msarabia@packet.com>

## Description
Port of change in the tinkerbell.org docs  - https://github.com/tinkerbell/tinkerbell.org/pull/144/

## Why is this needed

Catching up the new docs on par with the old docs.

Fixes: #

## How Has This Been Tested?
local mkdocs build


## How are existing users impacted? What migration steps/scripts do we need?

current users should not be impacted
