### PR TITLE
Fixing a missing tink in a template cli example

### DIFF
--- a/docs/cli-reference/template.md
+++ b/docs/cli-reference/template.md
@@ -38,7 +38,7 @@ tink template create --name <NAME> --path <PATH> [--help] [--facility]
 **Examples**
 
 ```
-template create --name hello-world < ./hello-world.yml
+tink template create --name hello-world < ./hello-world.yml
 >
 Created Template:  b8dbcf07-39dd-4018-903e-1748ecbd1986
 ```


### PR DESCRIPTION
Signed-off-by: DailyAlice <msarabia@equinix.com>

## Description

adds the `tink` to the `tink template create` example

## Why is this needed

Fixes: https://github.com/tinkerbell/tinkerbell.org/issues/158

## How Has This Been Tested?

local mkdocs build

## How are existing users impacted? What migration steps/scripts do we need?

No impact to existing users