### PR TITLE
click-to-copy code block fix

### DIFF
--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -183,7 +183,8 @@ EOF
 Create the template and push it to the database with the `tink template create` command.
 
 ```
-docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
+docker exec -i deploy_tink-cli_1 tink template create \
+  --name hello-world < ./hello-world.yml
 ```
 
 The command returns a Template ID, and if you are watching the `tink-server` logs you will see:

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -42,8 +42,6 @@ Since Vagrant is handling the Provisioner's configuration, including installing 
 
 ```
 vagrant up provisioner
->
-Bringing machine 'provisioner' up with 'virtualbox' provider...
 ```
 
 The Provisioner installs and runs Ubuntu with a couple of additional utilities. The time it takes to spin up the Provisioner varies with connection speed and resources on your local machine.
@@ -60,8 +58,6 @@ Now that the Provisioner's machine is up and running, you can connect and bring 
 
 ```
 vagrant ssh provisioner
->
-vagrant@provisioner:~$
 ```
 
 Tinkerbell is going to be running from a container, so navigate to the `vagrant` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
@@ -77,7 +73,10 @@ Tinkerbell is now ready to receive templates and workflows. Check out all the Ti
 
 ```
 docker-compose ps
->
+```
+
+The response shows the running services.
+```
         Name                      Command                  State                             Ports
 -------------------------------------------------------------------------------------------------------------------------
 deploy_boots_1         /boots -dhcp-addr 0.0.0.0: ...   Up
@@ -154,7 +153,6 @@ Then, push the hardware data to the database with the `tink hardware push` comma
 
 ```
 docker exec -i deploy_tink-cli_1 tink hardware push < ./hardware-data.json
-> 2020/06/17 14:12:45 Hardware data pushed successfully
 ```
 
 If you are following along in the `tink-server` logs, you should see:
@@ -186,8 +184,6 @@ Create the template and push it to the database with the `tink template create` 
 
 ```
 docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
->
-Created Template:  75ab8483-6f42-42a9-a80d-a9f6196130df
 ```
 
 The command returns a Template ID, and if you are watching the `tink-server` logs you will see:
@@ -209,8 +205,6 @@ Combine these two pieces of information and create the workflow with the `tink w
 docker exec -i deploy_tink-cli_1 tink workflow create \
     -t <TEMPLATE ID> \
     -r '{"device_1":"08:00:27:00:00:01"}'
->
-Created Workflow:  a8984b09-566d-47ba-b6c5-fbe482d8ad7f
 ```
 
 The command returns a Workflow ID and if you are watching the logs, you will see:

--- a/docs/setup/packet-terraform.md
+++ b/docs/setup/packet-terraform.md
@@ -40,7 +40,12 @@ Once you have your variables set, run the Terraform commands:
 ```
 terraform init --upgrade
 terraform apply
->
+
+```
+
+As an output, the `terraform apply` command returns the IP address of the Provisioner, the MAC address of the Worker, and an address for the SOS console of the Worker which will help you to follow what the Worker is doing. For example,
+
+```
 Apply complete! Resources: 5 added, 0 changed, 1 destroyed.
 
 Outputs:
@@ -54,8 +59,6 @@ worker_sos = [
   "4ac95ae2-6423-4cad-b91b-3d8c2fcf38d9@sos.dc13.packet.net",
 ]
 ```
-
-As an output, the `terraform apply` command returns the IP address of the Provisioner, the MAC address of the Worker, and an address for the SOS console of the Worker which will help you to follow what the Worker is doing.
 
 ### Troubleshooting - Server Creation
 
@@ -140,11 +143,15 @@ cd ./deploy
 docker-compose up -d
 ```
 
-To check if all the services are up and running you can use docker-compose as well. The output should look similar to:
+To check if all the services are up and running you can use `docker-compose`. 
 
 ```
 docker-compose ps
->
+```
+
+The output should look similar to:
+
+```
         Name                      Command               State                         Ports
 ------------------------------------------------------------------------------------------------------------------
 deploy_boots_1         /boots -dhcp-addr 0.0.0.0: ...   Up
@@ -212,8 +219,6 @@ Now we can push the hardware data to `tink-server`:
 
 ```
 docker exec -i deploy_tink-cli_1 tink hardware push < /root/tink/deploy/hardware-data-0.json
->
-2020/06/17 14:12:45 Hardware data pushed successfully
 ```
 
 A note on the Worker at this point. Ideally the worker should be kept from booting until the Provisioner is ready to serve it OSIE, but on Equinix Metal that probably doesn't happen. Now that the Worker's hardware data is registered with Tinkerbell, you should manually reboot the worker through the [Equinix Metal CLI](https://github.com/packethost/packet-cli/blob/master/docs/packet_device_reboot.md), [API](https://metal.equinix.com/developers/api/devices/#devices-performAction), or Equinix Metal console. Remember to use the SOS console to check what the Worker is doing.
@@ -240,9 +245,7 @@ EOF
 Create the template and push it to the `tink-server` with the `tink template create` command.
 
 ```
-$ docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
-
-Created Template:  75ab8483-6f42-42a9-a80d-a9f6196130df
+docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
 ```
 
 {{% notice note %}}
@@ -250,7 +253,7 @@ TIP: export the the template ID as a bash variable for future use.
 {{% /notice %}}
 
 ```
-$ export TEMPLATE_ID=75ab8483-6f42-42a9-a80d-a9f6196130df
+export TEMPLATE_ID=75ab8483-6f42-42a9-a80d-a9f6196130df
 ```
 
 ## Creating a Workflow
@@ -263,11 +266,9 @@ The next step is to combine both the hardware data and the template to create a 
 Combine these two pieces of information and create the workflow with the `tink workflow create` command.
 
 ```
-$ docker exec -i deploy_tink-cli_1 tink workflow create \
+docker exec -i deploy_tink-cli_1 tink workflow create \
     -t $TEMPLATE_ID \
     -r '{"device_1":'$(jq .network.interfaces[0].dhcp.mac hardware-data-0.json)'}'
-
-Created Workflow:  a8984b09-566d-47ba-b6c5-fbe482d8ad7f
 ```
 
 {{% notice note %}}
@@ -275,7 +276,7 @@ TIP: export the the workflow ID as a bash variable.
 {{% /notice %}}
 
 ```
-$ export WORKFLOW_ID=a8984b09-566d-47ba-b6c5-fbe482d8ad7f
+export WORKFLOW_ID=a8984b09-566d-47ba-b6c5-fbe482d8ad7f
 ```
 
 The command returns a Workflow ID and if you are watching the logs, you will see:
@@ -294,13 +295,13 @@ ssh $(terraform output -json worker_sos | jq -r '.[0]')
 
 You can also use the CLI from the provisioner to validate if the workflow completed correctly using the `tink workflow events` command.
 
-{{% notice note %}}
-Note that an event can take ~5 minutes to show up.
-{{% /notice %}}
-
 ```
 docker exec -i deploy_tink-cli_1 tink workflow events $WORKFLOW_ID
->
+```
+
+The response will look something like:
+
+```
 +--------------------------------------+-------------+-------------+----------------+---------------------------------+--------------------+
 | WORKER ID                            | TASK NAME   | ACTION NAME | EXECUTION TIME | MESSAGE                         |      ACTION STATUS |
 +--------------------------------------+-------------+-------------+----------------+---------------------------------+--------------------+
@@ -308,6 +309,10 @@ docker exec -i deploy_tink-cli_1 tink workflow events $WORKFLOW_ID
 | ce2e62ed-826f-4485-a39f-a82bb74338e2 | hello world | hello_world |              0 | Finished Execution Successfully |     ACTION_SUCCESS |
 +--------------------------------------+-------------+-------------+----------------+---------------------------------+--------------------+
 ```
+
+{{% notice note %}}
+Note that an event can take ~5 minutes to show up.
+{{% /notice %}}
 
 ## Cleanup
 


### PR DESCRIPTION
## Description

click-to-copy code does not also copy sample responses

## Why is this needed
https://github.com/tinkerbell/tinkerbell-docs/issues/29

## How Has This Been Tested?

local mkdocs build

## How are existing users impacted? What migration steps/scripts do we need?

no impact to existing users
