### PR TITLE
fixing links to CLI examples in the template docs

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -75,8 +75,8 @@ Templates are each stored as blobs in the database; they are later parsed during
 
 A Template is pushed to the database on the Provisioner with the [`tink template create`](/cli-reference/template/#tink-template-create) command which returns a generated UUID for the template.
 
-A template can be retrieved from the database with that ID and [`tink template get`](cli-reference/template/#tink-template-get). Similarly it can be deleted with [`tink template delete`](cli-reference/template/#tink-template-delete).
+A template can be retrieved from the database with that ID and [`tink template get`](/cli-reference/template/#tink-template-get). Similarly it can be deleted with [`tink template delete`](/cli-reference/template/#tink-template-delete).
 
-You can list all the templates that are stored in the database with [`tink template list`](cli-reference/template/#tink-template-list). Update the name or the contents of a template with the [`tink template update`](cli-reference/template/#tink-template-update) command.
+You can list all the templates that are stored in the database with [`tink template list`](/cli-reference/template/#tink-template-list). Update the name or the contents of a template with the [`tink template update`](/cli-reference/template/#tink-template-update) command.
 
 A complete list of CLI commands and examples is in the [CLI Reference](/cli-reference/template/).


### PR DESCRIPTION
## Description

fixes relative links so that they work

## Why is this needed

https://github.com/tinkerbell/tinkerbell-docs/issues/57

