### PR TITLE
Updates Terraform doc to reflect changes from sandbox#51

### DIFF
--- a/docs/setup/equinix-metal-terraform.md
+++ b/docs/setup/equinix-metal-terraform.md
@@ -14,7 +14,7 @@ This guide assumes that you already have:
 - [An Equinix Metal account](https://console.equinix.com/login).
 - Your Equinix Metal API Key and Project ID. The Terraform provider needs to have both to create servers in your account. Make sure the API token is a user API token (created/accessed under _API keys_ in your personal settings).
 - [SSH Keys](https://metal.equinix.com/developers/docs/accounts/ssh-keys/) need to be set up on Equinix Metal for the machine where you are running Terraform. Terraform uses your `ssh-agent` to connect to the Provisioner when needed. Double check that the right keys are set.
-- [Terraform](https://www.terraform.io/downloads.html) and the [Equinix Metal Terraform provider](https://registry.terraform.io/providers/packethost/packet/latest/docs) installed on your local machine.
+- [Terraform](https://www.terraform.io/downloads.html) and the [Equinix Metal Terraform provider](https://registry.terraform.io/providers/equinix/metal/latest/docs) installed on your local machine.
 
 ## Using Terraform
 
@@ -25,11 +25,11 @@ git clone https://github.com/tinkerbell/sandbox.git
 cd sandbox/deploy/terraform
 ```
 
-The Equinix Metal Terraform module requires a couple of inputs, the mandatory ones are the `packet_api_token` and the `project_id`. You can define them in a `terraform.ftvars` file. By default, Terraform will load the file when present. You can create one `terraform.tfvars` that looks like this:
+The Equinix Metal Terraform module requires a couple of inputs, the mandatory ones are the `metal_api_token` and the `project_id`. You can define them in a `terraform.ftvars` file. By default, Terraform will load the file when present. You can create one `terraform.tfvars` that looks like this:
 
 ```
 cat terraform.tfvars
-packet_api_token = "awegaga4gs4g"
+metal_api_token = "awegaga4gs4g"
 project_id = "235-23452-245-345"
 ```
 
@@ -50,13 +50,13 @@ Apply complete! Resources: 5 added, 0 changed, 1 destroyed.
 
 Outputs:
 
-provisioner_dns_name = eef33e97.packethost.net
+provisioner_dns_name = eef33e97.platformequinix.com
 provisioner_ip = 136.144.56.237
 worker_mac_addr = [
   "1c:34:da:42:d3:20",
 ]
 worker_sos = [
-  "4ac95ae2-6423-4cad-b91b-3d8c2fcf38d9@sos.dc13.packet.net",
+  "4ac95ae2-6423-4cad-b91b-3d8c2fcf38d9@sos.dc13.platformequinix.com",
 ]
 ```
 
@@ -163,7 +163,7 @@ deploy_tink-cli_1      /bin/sh -c sleep infinity        Up
 deploy_tink-server_1   tink-server                      Up      0.0.0.0:42113->42113/tcp, 0.0.0.0:42114->42114/tcp
 ```
 
-You now have a Provisioner up and running on Packet. The next steps take you through creating a workflow and pushing it to the Worker using the `hello-world` workflow example. If you want to use the example, you need to pull the `hello-world` image from from Docker Hub to the internal registry.
+You now have a Provisioner up and running on Equinix Metal. The next steps take you through creating a workflow and pushing it to the Worker using the `hello-world` workflow example. If you want to use the example, you need to pull the `hello-world` image from from Docker Hub to the internal registry.
 
 ```
 docker pull hello-world
@@ -287,7 +287,7 @@ tink-server_1  | {"level":"info","ts":1592936829.6773047,"caller":"grpc-server/w
 
 ## Checking Workflow Status
 
-You can not SSH directly into the Worker but you can use the `SOS` or `Out of bond` console provided by Packet to follow what happens in the Worker during the workflow. You can SSH into the SOS console with:
+You can not SSH directly into the Worker but you can use the `SOS` or `Out of bond` console provided by Equinix Metal to follow what happens in the Worker during the workflow. You can SSH into the SOS console with:
 
 ```
 ssh $(terraform output -json worker_sos | jq -r '.[0]')

--- a/docs/setup/using-qemu.md
+++ b/docs/setup/using-qemu.md
@@ -86,6 +86,14 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
      libguestfs-tools \
      libosinfo-bin \
      git
+     jq
+    ```
+This installation method also requires Docker and [`docker-compose`](https://docs.docker.com/compose/install/#install-compose-on-linux-systems):
+
+    ```
+    apt-get install -y docker.io \
+    curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    chmod +x /usr/local/bin/docker-compose
     ```
 
 3. Grab shack (QEMU wrapper).
@@ -129,7 +137,7 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
     We can also examine that this has worked, by examining `ip addr`:
 
     ```
-    11: plunder: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    11: tinkerbell: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
         link/ether 2a:27:61:44:d2:07 brd ff:ff:ff:ff:ff:ff
         inet 192.168.1.1/24 brd 192.168.1.255 scope global plunder
            valid_lft forever preferred_lft forever
@@ -158,7 +166,7 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
 9. Configure the sandbox.
 
     ```
-    ./generate-envrc.sh plunder > .env
+    ./generate-envrc.sh tinkerbell > .env
     ./setup.sh
     ```
 
@@ -166,7 +174,7 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
 
     ```
     # Add Nginx address to Tinkerbell
-    sudo ip addr add 192.168.1.2/24 dev plunder
+    sudo ip addr add 192.168.1.2/24 dev tinkerbell
     cd deploy
     source ../.env; docker-compose up -d
     ```

--- a/docs/setup/using-qemu.md
+++ b/docs/setup/using-qemu.md
@@ -91,8 +91,8 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
 This installation method also requires Docker and [`docker-compose`](https://docs.docker.com/compose/install/#install-compose-on-linux-systems):
 
     ```
-    apt-get install -y docker.io \
-    curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    apt-get install -y docker.io ; \
+    curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
     chmod +x /usr/local/bin/docker-compose
     ```
 

--- a/docs/setup/using-qemu.md
+++ b/docs/setup/using-qemu.md
@@ -91,9 +91,9 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
 This installation method also requires Docker and [`docker-compose`](https://docs.docker.com/compose/install/#install-compose-on-linux-systems):
 
     ```
-    apt-get install -y docker.io ; \
-    curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
-    chmod +x /usr/local/bin/docker-compose
+     apt-get install -y docker.io ; \
+     curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
+     chmod +x /usr/local/bin/docker-compose
     ```
 
 3. Grab shack (QEMU wrapper).

--- a/docs/setup/using-qemu.md
+++ b/docs/setup/using-qemu.md
@@ -90,11 +90,11 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
     ```
 This installation method also requires Docker and [`docker-compose`](https://docs.docker.com/compose/install/#install-compose-on-linux-systems):
 
-    ```
+```
     apt-get install -y docker.io ; \
-     curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
-     chmod +x /usr/local/bin/docker-compose
-    ```
+    curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
+    chmod +x /usr/local/bin/docker-compose
+```
 
 3. Grab shack (QEMU wrapper).
 

--- a/docs/setup/using-qemu.md
+++ b/docs/setup/using-qemu.md
@@ -91,7 +91,7 @@ In this example I'll be deploying a `c3.small.x86` in the Amsterdam facility `am
 This installation method also requires Docker and [`docker-compose`](https://docs.docker.com/compose/install/#install-compose-on-linux-systems):
 
     ```
-     apt-get install -y docker.io ; \
+    apt-get install -y docker.io ; \
      curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ; \
      chmod +x /usr/local/bin/docker-compose
     ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ nav:
   - Setups:
     - Local Setup with Vagrant: setup/local-vagrant.md
     - Extending the Vagrant Setup: setup/extending-vagrant.md
-    - Equinix Metal Setup with Terraform: setup/packet-terraform.md
+    - Equinix Metal Setup with Terraform: setup/equinix-metal-terraform.md
     - Bare Metal or Equinix Metal with QEMU: setup/using-qemu.md
     - On bare metal with Docker: setup/on-bare-metal-with-docker.md
 


### PR DESCRIPTION
## Description
In https://github.com/tinkerbell/sandbox/pull/51 I have updated the Terraform setup plan, this change updates the documentation to reflect this, but also renames the document and navigation item to use this new named document.

## Why is this needed

Consistency with renaming/rebranding effort across the organization.

Fixes: #

Ran `mkdocs serve` in venv, and navigation worked as expected to the updated document, which rendered as expected.


## How are existing users impacted? What migration steps/scripts do we need?

No change for existing users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
