### PR TITLE
Add ActionHub to main content table

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Templates: templates.md
 
   - Actions:
+    - ActionHub: https://artifacthub.io/packages/search?kind=4
     - Action Architecture: actions/action-architecture.md
     - Creating a Basic Action: actions/creating-a-basic-action.md
   


### PR DESCRIPTION
Thanks to the work Dan is mainly doing we now have a good amount of
actions. And more are coming as you can see from the open PR we have in
tinkerbell/hub repo.

I think it is time to officially link this initiative to the
documentation.

I think more about how to actually contribute can be covered as part of
the Contributor subsection of the documentation.
