### PR TITLE
Removes reference to CLI flag that apparently no longer exists in tin…

### DIFF
--- a/docs/setup/equinix-metal-terraform.md
+++ b/docs/setup/equinix-metal-terraform.md
@@ -245,7 +245,7 @@ EOF
 Create the template and push it to the `tink-server` with the `tink template create` command.
 
 ```
-docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
+docker exec -i deploy_tink-cli_1 tink template create < ./hello-world.yml
 ```
 
 {{% notice note %}}


### PR DESCRIPTION
…k template creation

## Description

The setup guide includes a CLI argument that apparently no longer exists when creating a template.

## Why is this needed

When following the guide, I run the command as documented:

```
root@tink-provisioner:~/tink/deploy# docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
Error: unknown flag: --name
Usage:
  tink template create [flags]

Flags:
      --file string   path to the template file (default "./template.yaml")
  -h, --help          help for create

Global Flags:
  -f, --facility string   used to build grpc and http urls

unknown flag: --name
```

Fixes: #

Removing the flag successfully creates the workflow:

```
root@tink-provisioner:~/tink/deploy# docker exec -i deploy_tink-cli_1 tink template create < ./hello-world.yml
Created Template:  42bfe289-924c-11eb-9e33-0242ac120005

root@tink-provisioner:~/tink/deploy# docker exec -i deploy_tink-cli_1 tink template get
+--------------------------------------+----------------------+----------------------+----------------------+
| ID                                   | NAME                 | CREATED AT           | UPDATED AT           |
+--------------------------------------+----------------------+----------------------+----------------------+
| 42bfe289-924c-11eb-9e33-0242ac120005 | hello_world_workflow | 2021-03-31T18:09:39Z | 2021-03-31T18:09:39Z |
+--------------------------------------+----------------------+----------------------+----------------------+
```