### PR TITLE
Latest version of tink-cli doesn't support `--name`

### DIFF
--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -184,7 +184,7 @@ Create the template and push it to the database with the `tink template create` 
 
 ```
 docker exec -i deploy_tink-cli_1 tink template create \
-  --name hello-world < ./hello-world.yml
+  < ./hello-world.yml
 ```
 
 The command returns a Template ID, and if you are watching the `tink-server` logs you will see:


### PR DESCRIPTION
## Description

Remove `--name` for tink template create in vagrant getting started docs. 


## Why is this needed
Instructions fail with latest vagrant up.

Fixes: #
No issue, doc update only.

## How Has This Been Tested?
Fails:
```
vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ./hello-world.yml
Error: unknown flag: --name
Usage:
  tink template create [flags]

Flags:
      --file string   path to the template file (default "./template.yaml")
  -h, --help          help for create

Global Flags:
  -f, --facility string   used to build grpc and http urls

unknown flag: --name
```

Works:
```
vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink template create < ./hello-world.yml
Created Template:  cbc189b4-947f-11eb-ab36-0242ac120005
```

## How are existing users impacted? What migration steps/scripts do we need?

N/A


## Checklist:

I have:

- [*] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
