### PR TITLE
Fixed generate env script

### DIFF
--- a/docs/setup/on-bare-metal-with-docker.md
+++ b/docs/setup/on-bare-metal-with-docker.md
@@ -58,7 +58,7 @@ In this case we are using the latest sandbox release that today is [v0.4.0](http
 The sandbox sets up Tinkerbell using the `setup.sh` script. `setup.sh` relies on a `.env` file that can be generated running the command:
 
 ```
-./generate-envrc.sh <network-interface> > .env
+./generate-env.sh <network-interface> > .env
 ```
 
 In this case, the `network-interface` is `eth1`. The output of this command will be stored inside `./.env`. It will look like this:


### PR DESCRIPTION
## Description

The `generate-envrc.sh` was renamed to `generate-env.sh` in tinkerbell/sandbox#79, but not updated in the docs 

## Why is this needed

It was wrong :)

Fixes: #

N/A

## How Has This Been Tested?
N/A

## How are existing users impacted? What migration steps/scripts do we need?

Frustration by incorrect docs :)

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade

N/A