### PR TITLE
Small issue in docker example

### DIFF
--- a/docs/deploying-operating-systems/examples-ubuntu.md
+++ b/docs/deploying-operating-systems/examples-ubuntu.md
@@ -143,7 +143,6 @@ tasks:
 	  - /dev/console:/dev/console
 	  - /lib/firmware:/lib/firmware:ro
 	actions:
-	  actions:
 	  - name: "disk-wipe-partition"
 		image: quay.io/tinkerbell-actions/rootio:v1.0.0
 		timeout: 90


### PR DESCRIPTION
## Description
The word "actions:" was listed twice in a row making the yaml invalid

## Why is this needed
To have accurate documentation. 

## How Has This Been Tested?
By reading

## How are existing users impacted? What migration steps/scripts do we need?
Things will work now
