### PR TITLE
Update Slack links to slack.cncf.org

### DIFF
--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -9,7 +9,7 @@ Tinkerbell is an open source project made of different components, and a lot of 
 
 The projects inside Tinkerbell are designed to be as independent as possible, some are ready and others have a long way to go. In general, deciding where you want to contribute depends on what you are working towards.
 
-The best way to start is to join the `#tinkerbell` channel over on the [Equinix Metal Slack](https://slack.equinixmetal.com/) or the [Contributor Mailing list](https://github.com/tinkerbell/.github/blob/master/COMMUNICATION.md#contributors-mailing-list). You can find more about how we communicate on the [COMMUNICATION page](https://github.com/tinkerbell/.github/blob/master/COMMUNICATION.md) in the `tinkerbell/.github` repo.
+The best way to start is to join the `#tinkerbell` channel over on the [CNCF Slack ](https://slack.cncf.org/) or the [Contributor Mailing list](https://github.com/tinkerbell/.github/blob/master/COMMUNICATION.md#contributors-mailing-list). You can find more about how we communicate on the [COMMUNICATION page](https://github.com/tinkerbell/.github/blob/master/COMMUNICATION.md) in the `tinkerbell/.github` repo.
 
 ## Contributing to the Codebase
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,5 +51,5 @@ In addition to the microservices, there are three pieces of infrastructure:
 Need a little help getting started? We're here!
 
 - Check out the [FAQs](https://tinkerbell.org/faq/) - When there are questions, we document the answers.
-- Join our [Community Slack](https://slack.equinixmetal.com/). Look for the `#tinkerbell` channel.
+- Join the [CNCF Community Slack](https://slack.cncf.org/). Look for the `#tinkerbell` channel.
 - Submit an issue on [Github](https://github.com/tinkerbell/).

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -254,4 +254,4 @@ Getting set up locally is a good way to sample Tinkerbell's functionality. The V
 
 If you are looking to extend your local setup to develop or test out other workflows, check out the [Extending the Vagrant Setup](/setup/extending-vagrant) doc.
 
-That's it! Let us know what you think about it on [Slack](https://slack.equinixmetal.com/).
+That's it! Let us know what you think about it in the #tinkerbell channel on the [CNCF Community Slack](https://slack.cncf.org/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/tinkerbell
     - icon: fontawesome/brands/slack
-      link: https://slack.equinixmetal.com/
+      link: https://slack.cncf.org/
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/tinkerbell_oss
 


### PR DESCRIPTION
## Description

Update Slack references to the new location.

## Why is this needed

We moved the channel!

## How Has This Been Tested?

`mkdocs serve`
