### PR TITLE
Various docs updates for Vagrant users

### DIFF
--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -107,8 +107,8 @@ The last step for the Provisioner to do at this point is to pull down the image 
 
 ```
 docker pull hello-world
-docker tag hello-world 192.168.1.1/hello-world
-docker push 192.168.1.1/hello-world
+docker tag hello-world 192.168.50.4/hello-world
+docker push 192.168.50.4/hello-world
 ```
 
 ## Creating the Worker's Hardware Data

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -66,7 +66,7 @@ vagrant ssh provisioner
 Tinkerbell is going to be running from a container, so navigate to the `vagrant` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
 
 ```
-cd /vagrant && source .env && cd deploy
+cd /vagrant/compose && source .env
 docker-compose up -d
 ```
 

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -63,9 +63,11 @@ Now that the Provisioner's machine is up and running, SSH into the Provisioner.
 vagrant ssh provisioner
 ```
 
-The Tinkerbell stack is already running in a set of container through Docker Compose. Check that all the Tinkerbell services are running.
+The Tinkerbell stack is already running in a set of containers through Docker Compose. Check that all the Tinkerbell services are running.
 
 ```
+cd /vagrant/compose
+source .env
 docker-compose ps
 ```
 

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -92,13 +92,13 @@ deploy_tink-cli_1      /bin/sh -c sleep infinity        Up
 deploy_tink-server_1   tink-server                      Up (healthy)   0.0.0.0:42113->42113/tcp, 0.0.0.0:42114->42114/tcp
 ```
 
-At this point, you might want to open a ssh connection to show logs from the Provisioner, because it will show what the `tink-server` is doing through the rest of the setup. Open a new terminal, ssh in to the provisioner as you did before, and run `docker-compose logs` to tail logs.
+At this point, you might want to open a ssh connection to show logs from the Provisioner, because it will show what the `tink-server` is doing through the rest of the setup. Open a new terminal, ssh in to the provisioner as you did before, and run `docker-compose logs -f` to tail logs.
 
 ```
 cd sandbox/deploy/vagrant
 vagrant ssh provisioner
-cd /vagrant && source .env && cd deploy
-docker-compose logs -f tink-server boots nginx
+cd /vagrant/compose && source .env
+docker-compose logs -f tink-server boots hegel
 ```
 
 Later in the tutorial you can check the logs from `tink-server` in order to see the execution of the workflow.

--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -21,6 +21,9 @@ The last step is to start up the Worker, which will call back to the Provisioner
 - [The host's processor should support virtualization](https://www.cyberciti.biz/faq/linux-xen-vmware-kvm-intel-vt-amd-v-support/)
 - [Vagrant](https://www.vagrantup.com/downloads) is installed
 - Either [VirtualBox](https://www.virtualbox.org/) or [libvirtd](https://libvirt.org/) is installed.
+- If using VirtualBox be sure to install both:
+  - The Vagrant *vagrant-vbguest* plugin: `vagrant plugin install vagrant-vbguest`
+  - The [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
 
 ## Getting Tinkerbell
 


### PR DESCRIPTION
## Description

Added a couple of lines to make things easier for new users.

## Why is this needed

1. If you don't have [these installed](https://github.com/tinkerbell/tinkerbell-docs/pull/127/commits/c49eb89fce9976eba47fdfb38427b013a9649ca3), you can get a variety of errors, but the main one you'll hit first is this (when running `vagrant up provisioner`):

```
Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o uid=1000,gid=1000,_netdev vagrant /vagrant

The error output from the command was:

/sbin/mount.vboxsf: mounting failed with the error: Invalid argument
```
Googling this points you in a number of places, many of which only apply to Mac users. This change should save others the time I spent finding the right cause.

2. It seems the directory structure was changed in https://github.com/tinkerbell/sandbox/commit/d6af9a49afa9ad2cfe362e9f7c5d3a852cdffa13#diff-8df58975fe0191ccc9caf1c459154641fc45c74a7c28ac3a71f565a5edd98b6e so I updated the paths in the docs.

3. The TINKERBELL_HOST_IP was changed at some point so I updated it, **but** the interactions with the registry don't work and I ran out of time looking into why. Here's the flow: EDIT: It's likely this: https://github.com/tinkerbell/sandbox/issues/105

```
$ echo $TINKERBELL_HOST_IP
192.168.50.4
$ docker pull hello-world
Using default tag: latest
latest: Pulling from library/hello-world
Digest: sha256:9ade9cc2e26189a19c2e8854b9c8f1e14829b51c55a630ee675a5a9540ef6ccf
Status: Downloaded newer image for hello-world:latest
docker.io/library/hello-world:latest
$ docker tag hello-world 192.168.50.4/hello-world
$ docker push 192.168.50.4/hello-world
Using default tag: latest
The push refers to repository [192.168.50.4/hello-world]
Get "https://192.168.50.4/v2/": x509: certificate signed by unknown authority
$ echo $?
1
```

4. Removed the `docker-compose up` section as this now happens in the Vagrant provisioning.

Fixes: #

## How Has This Been Tested?

1. The instructions in the readme don't work for running MkDocs, so I eyeballed the changes in Github.
2. Ran through them all again from fresh

$ vagrant --version
Vagrant 2.2.18
$ vboxmanage --version
6.1.26r145957

## How are existing users impacted? What migration steps/scripts do we need?

n/a

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
