### PR TITLE
Update Local setup with Vagrant documentation

### DIFF
--- a/docs/setup/local-vagrant.md
+++ b/docs/setup/local-vagrant.md
@@ -64,10 +64,10 @@ vagrant ssh provisioner
 vagrant@provisioner:~$
 ```
 
-Tinkerbell is going to be running from a container, so navigate to the `vagrant` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
+Tinkerbell is going to be running from a container, so navigate to the `/vagrant/compose` directory, set the environment, and start the Tinkerbell stack with `docker-compose`.
 
 ```
-cd /vagrant && source .env && cd deploy
+cd /vagrant/compose && source .env
 docker-compose up -d
 ```
 
@@ -93,10 +93,10 @@ deploy_tink-server_1   tink-server                      Up (healthy)   0.0.0.0:4
 At this point, you might want to open a ssh connection to show logs from the Provisioner, because it will show what the `tink-server` is doing through the rest of the setup. Open a new terminal, ssh in to the provisioner as you did before, and run `docker-compose logs` to tail logs.
 
 ```
-cd tink/deploy/vagrant
+cd sandbox/deploy/vagrant
 vagrant ssh provisioner
-cd /vagrant && source .env && cd deploy
-docker-compose logs -f tink-server boots nginx
+cd /vagrant/compose && source .env
+docker-compose logs -f tink-server boots osie-bootloader
 ```
 
 Later in the tutorial you can check the logs from `tink-server` in order to see the execution of the workflow.


### PR DESCRIPTION
## Description

Update the Local Setup with Vagrant setup guide to work with the current version of Sandbox. 

## Why is this needed

Fixes: The guide as written doesn't work due to many changed directory paths, conflicting MAC addresses in the guide already existing in the repo, the docker registry requiring SSL now by default, and more. This is just a quick cleanup to make it at least function as written.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran through the setup and validated the examples worked and provided the stated output.
<!--- Include details of your testing environment, and the tests you ran to -->
Linux Ubuntu 20.04 with libvirt.
<!--- see how your change affects other areas of the code, etc. -->
It doesn't touch any code, just this one documentation file.


## How are existing users impacted? What migration steps/scripts do we need?

Documentation will actually work for the vagrant setup workflow.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [O] added unit or e2e tests
- [O] provided instructions on how to upgrade
