### PR TITLE
Update link in documentation for docker quick start

### DIFF
--- a/docs/setup/on-bare-metal-with-docker.md
+++ b/docs/setup/on-bare-metal-with-docker.md
@@ -11,7 +11,7 @@ More than a documentation, this is an example of installing Tinkerbell in a home
 2. Tink Server
 3. Tink CLI
 4. PostgreSQL
-5. And everything that runs as part of the [docker-compose in sandbox](https://github.com/tinkerbell/sandbox/blob/main/deploy/docker-compose.yml)
+5. And everything that runs as part of the [docker-compose in sandbox](https://github.com/tinkerbell/sandbox/blob/main/deploy/compose/docker-compose.yml)
 
 This page is inspired by [Aaron](https://geekgonecrazy.com/) a community member who wrote ["Tinkerbell or iPXE boot on OVH"](https://geekgonecrazy.com/2020/09/07/tinkerbell-or-ipxe-boot-on-ovh/).
 


### PR DESCRIPTION
Signed-off-by: J. Gavin Ray <git@jgavinray.com>

## Description

This PR will update the link that is presented in the documentation to accurately reflect the recent changes in the sandbox repository.

## Why is this needed

The old link was broken.

Fixes: #
N/A

## How Has This Been Tested?
N/A


## How are existing users impacted? What migration steps/scripts do we need?

N/A


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade

