### PR TITLE
Add or update mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,24 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - check-success=DCO
+
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - base=main
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#review-requested=0"
+      - check-success=DCO
+      - label!=do-not-merge
+      - label=ready-to-merge
+    actions:
+      queue:
+        method: merge
+        name: default
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+
+          {{ body }}


### PR DESCRIPTION
This PR will either create a Mergify config if it doesn't exist or ensure it is up to date with recent mergify changes.

Mergify has deprecated strict mode in favor of build queues (https://blog.mergify.com/strict-mode-deprecation/), this updates existing configs to the new setup.
The `commit_message` field was also deprecated in favor of the more powerful `commit_message_template` field.
The mergify config file was moved to the .github folder to avoid muddying up the root dir.

This PR will also ensure every tinkerbell repo has a mergify config setup, since it doesn't block manual merges but is missed when not available by some.
