### PR TITLE
Remove redundant requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-markdown>=3.2
-mdx_truly_sane_lists
-mkdocs>=1.1
-mkdocs-material>=5.0
-mkdocs-versioning>=0.3
-poetry
-pygments>=2.4
-pymdown-extensions>=7.0


### PR DESCRIPTION
`requirements.txt` is typically used by pip to install a dependency set. We use poetry so the requirements.txt is redundant.