### PR TITLE
Update windows reboot action name (it will be used to create container)

### DIFF
--- a/docs/deploying-operating-systems/examples-win.md
+++ b/docs/deploying-operating-systems/examples-win.md
@@ -154,7 +154,7 @@ tasks:
 		  DEST_DISK: /dev/sda
 		  IMG_URL: "http://192.168.1.1:8080/tink-windows-2016.raw.gz"
 		  COMPRESSED: true
-      - name: "reboot into Windows"
+      - name: "reboot-into-Windows"
         image: local-registry/reboot:1.0
         timeout: 90
         volumes:


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>

## Description

<!--- Please describe what this PR is going to change -->
Resolve the reboot action failed issue in deploying Windows.

## Why is this needed
The action name is used to create the reboot container, the current name is not a valid one.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Apply the updated workflow to my test env, Windows can be deployed and rebooted successfully.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
