### PR TITLE
fix: Docs link for custom partitioning & raid

### DIFF
--- a/docs/deploying-operating-systems/the-deployment.md
+++ b/docs/deploying-operating-systems/the-deployment.md
@@ -216,7 +216,7 @@ Once an Operating System image **or** a filesystem + bootloader is deployed we m
 
 [archive2disk]: https://artifacthub.io/packages/tbaction/tinkerbell-community/archive2disk
 [centos/rhel]: https://github.com/dozzie/yumbootstrap
-[custom partitioning & raid]: https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/
+[custom partitioning & raid]: https://deploy.equinix.com/developers/docs/metal/storage/custom-partitioning-raid/
 [gzip]: https://en.wikipedia.org/wiki/Gzip
 [image2disk]: https://artifacthub.io/packages/tbaction/tinkerbell-community/image2disk
 [qcow]: https://en.wikipedia.org/wiki/Qcow


### PR DESCRIPTION
## Description

This PR fixes broken link for custom partitioning & raid in docs.

## Why is this needed

Broken Link

Fixes: #


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
